### PR TITLE
Add to unaryTest context input value that contains input expression name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -220,7 +220,11 @@ function evaluateRule(rule, resolvedInputExpressions, outputNames) {
                 inputValue = 'false'
             }
             const inputRule = rule.inputValues[i];
-            const res = unaryTest(inputRule, { '?': inputValue })
+            let context = { '?': inputValue };
+            if (inputRule.includes(resolvedInputExpressions[i].name)) {
+                context[resolvedInputExpressions[i].name] = inputValue;
+            }
+            const res = unaryTest(inputRule, context);
             // console.log('inputRule: ', inputRule, 'inputname: ', resolvedInputExpressions[i].name, 'inputValue: ', inputValue, 'res: ', res);
             if (!res) {
                 return {


### PR DESCRIPTION
- Creating context also based on input expressions that are part of input rule in order to process implementation `like contains` that feelin support

I had a use case that in input expression which had to evaluate if list passed in expression contains specific values. 
Let me give an example suppose that my dmn schema I want to evaluate a type as coverable with `50%` of damage and others as `90%`. So i create an input named `CarType` with expression `carType` and in input rule add a rule like `list contains(carType, "Ferrari", "Audi")` `then` `50%`, other `90%`.
Passing a context like 
```ts
const context = {
  carType: "BMW"
}

// or 
const context = {
  carType: "Ferrari"
}
```
Gives as results from `evaluateDecision(dmnTable, parsedDecisionTable, context)` the value `90%`.

`feelin` as `feel interpreter` already support this type of evaluation